### PR TITLE
Initialize folder structure and OTA base for profiles repository

### DIFF
--- a/.github/workflows/check_profiles.yml
+++ b/.github/workflows/check_profiles.yml
@@ -1,0 +1,85 @@
+name: Check profiles
+
+on: 
+  pull_request:
+    branches: 
+      - main 
+    paths:
+      - 'profiles/**'
+      - '.github/workflows/check_profiles.yml'
+
+  push:
+    branches:
+      - main
+    paths:
+      - 'profiles/**'
+      - 'scripts/pack_profiles.sh'
+
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'     
+        required: true
+        default: 'warning'
+
+jobs:
+  check_profiles:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download validator
+        run: |
+          curl -LJO https://github.com/SoftFever/Orca_tools/releases/download/1/OrcaSlicer_profile_validator
+          chmod +x ./OrcaSlicer_profile_validator
+
+      - name: Run validation for each profile version
+        run: |
+          for dir in ./profiles/*/
+          do
+            echo "Validating profiles in $dir"
+            python3 ./scripts/orca_extra_profile_check.py --dir "$dir"
+            ./OrcaSlicer_profile_validator -p "$dir" -l 2
+          done
+
+  release_profiles:
+    runs-on: ubuntu-24.04
+    needs: check_profiles
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up GitHub CLI
+        run: |
+          sudo apt update
+          sudo apt install gh -y
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Loop through profile versions and release each
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x ./scripts/pack_profiles.sh
+          mkdir -p output
+
+          TIMESTAMP=$(date +%s)
+
+          for dir in ./profiles/*/; do
+            VERSION=$(basename "$dir")
+            NUMBER="$TIMESTAMP"
+            ZIP_NAME="orcaslicer-profiles_ota_${VERSION}.${NUMBER}.zip"
+            echo "Packaging $VERSION"
+
+            ./scripts/pack_profiles.sh "$VERSION" "$NUMBER"
+            mv "./orcaslicer-profiles_ota_${VERSION}.${NUMBER}.zip" ./output/
+
+            echo "Creating/updating release for $VERSION"
+            gh release delete "$VERSION" -y || true
+            gh release create "$VERSION" ./output/$ZIP_NAME \
+              --title "$VERSION" \
+              --notes "Automated release of profiles for $VERSION"
+          done
+

--- a/.github/workflows/check_profiles.yml
+++ b/.github/workflows/check_profiles.yml
@@ -46,7 +46,7 @@ jobs:
   release_profiles:
     runs-on: ubuntu-24.04
     needs: check_profiles
-
+    if: ${{github.ref == 'refs/heads/main'}}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/scripts/generate_presets_vendors.py
+++ b/scripts/generate_presets_vendors.py
@@ -1,0 +1,161 @@
+# helps manage the static list of vendor names in src/slic3r/GUI/CreatePresetsDialog.cpp
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+scripts_dir = Path(__file__).resolve().parent
+print(f'Scripts dir: {scripts_dir}')
+root_dir = scripts_dir.parent
+profiles_dir = root_dir / 'resources' / 'profiles'
+
+printers: Dict[str, List[str]] = {}
+
+# generates the printer vendor list
+print(f'Looking in {profiles_dir.resolve()}')
+for entry in profiles_dir.glob('*.json'):
+    if entry.is_file():
+        entry_info = json.loads(entry.read_text())
+        vendor_name = entry_info.get('name', None)
+        if vendor_name and vendor_name != 'Custom Printer':
+            models = [machine.get('name', None) for machine in entry_info.get('machine_model_list', []) if machine.get('name', None)]
+            if not models:
+                continue
+            printers[vendor_name] = models
+
+vendor_names = [f'"{vendor_name}",' for vendor_name in sorted(printers.keys(), key=str.casefold)]
+vend_col_width = len(max(vendor_names, key=len))
+vendors_formatted = '    {' + '\n     '.join(' '.join(f"{vendor_name:{vend_col_width}}" for vendor_name in vendor_names[i:i+5]) for i in range(0, len(vendor_names), 5)).rstrip()[:-1] + '}'
+print(vendors_formatted)
+
+# generates the printer model map
+models_formatted = '    {'
+models_indent = len(models_formatted) + vend_col_width + 2
+for vendor_name in sorted(printers.keys(), key=str.casefold):
+    vendor_formatted = f'"{vendor_name}",'
+    models_formatted += f'{{{vendor_formatted:{vend_col_width}}{{'
+
+    model_names = printers[vendor_name]
+    model_names_formatted = [f'"{model_name}",' for model_name in model_names]
+    model_col_width = len(max(model_names_formatted, key=len))
+    model_names_str = ('\n' + ' ' * models_indent).join(' '.join(f"{model_name:{model_col_width}}" for model_name in model_names_formatted[i:i+5]) for i in range(0, len(model_names), 5)).rstrip()[:-1] + '}'
+
+    models_formatted += model_names_str
+    
+    models_formatted += '},\n     '
+
+models_formatted = models_formatted.rstrip()[:-1] + '}'
+print(models_formatted)
+
+
+# Generate Filament Vendors
+filament_vendors = [
+    '3Dgenius',
+    '3DJake',
+    '3DXTECH',
+    '3D BEST-Q',
+    '3D Hero',
+    '3D-Fuel',
+    'Aceaddity',
+    'AddNorth',
+    'Amazon Basics',
+    'AMOLEN',
+    'Ankermake',
+    'Anycubic',
+    'Atomic',
+    'AzureFilm',
+    'BASF',
+    'Bblife',
+    'BCN3D',
+    'Beyond Plastic',
+    'California Filament',
+    'Capricorn',
+    'CC3D',
+    'CERPRiSE',
+    'colorFabb',
+    'Comgrow',
+    'Cookiecad',
+    'Creality',
+    'Das Filament',
+    'DO3D',
+    'DOW',
+    'DREMC',
+    'DSM',
+    'Duramic',
+    'ELEGOO',
+    'Eryone',
+    'Essentium',
+    'eSUN',
+    'Extrudr',
+    'Fiberforce',
+    'Fiberlogy',
+    'FilaCube',
+    'Filamentive',
+    'FilamentOne',
+    'Fillamentum',
+    'Fil X',
+    'FLASHFORGE',
+    'Formfutura',
+    'Francofil',
+    'FusRock',
+    'GEEETECH',
+    'Giantarm',
+    'Gizmo Dorks',
+    'GreenGate3D',
+    'HATCHBOX',
+    'Hello3D',
+    'IC3D',
+    'IEMAI',
+    'IIID Max',
+    'INLAND',
+    'iProspect',
+    'iSANMATE',
+    'Justmaker',
+    'Keene Village Plastics',
+    'Kexcelled',
+    'LDO',
+    'MakerBot',
+    'MatterHackers',
+    'MIKA3D',
+    'NinjaTek',
+    'Nobufil',
+    'Novamaker',
+    'OVERTURE',
+    'OVVNYXE',
+    'Polymaker',
+    'Priline',
+    'Printed Solid',
+    'Protopasta',
+    'Prusament',
+    'Push Plastic',
+    'R3D',
+    'Re-pet3D',
+    'Recreus',
+    'Regen',
+    'Sain SMART',
+    'SliceWorx',
+    'Snapmaker',
+    'SnoLabs',
+    'Spectrum',
+    'SUNLU',
+    'TTYT3D',
+    'Tianse',
+    'UltiMaker',
+    'Valment',
+    'Verbatim',
+    'VO3D',
+    'Voxelab',
+    'VOXELPLA',
+    'YOOPAI',
+    'Yousu',
+    'Ziro',
+    'Zyltech',
+]
+
+filament_vendors_formatted = [f'"{vendor_name}",' for vendor_name in filament_vendors]
+fil_col_width = len(max(filament_vendors_formatted, key=len))
+filaments_formatted = '    {'
+filament_indent = len(filaments_formatted)
+filaments_formatted += ('\n' + ' ' * filament_indent).join(' '.join(f'{vendor_name:{fil_col_width}}' for vendor_name in filament_vendors_formatted[i:i+5]) for i in range(0, len(filament_vendors), 5)).rstrip()[:-1] + '};'
+print(filaments_formatted)

--- a/scripts/orca_extra_profile_check.py
+++ b/scripts/orca_extra_profile_check.py
@@ -1,0 +1,417 @@
+import os
+import json
+import argparse
+from pathlib import Path
+
+OBSOLETE_KEYS = {
+    "acceleration", "scale", "rotate", "duplicate", "duplicate_grid",
+    "bed_size", "print_center", "g0", "wipe_tower_per_color_wipe",
+    "support_sharp_tails", "support_remove_small_overhangs", "support_with_sheath",
+    "tree_support_collision_resolution", "tree_support_with_infill",
+    "max_volumetric_speed", "max_print_speed", "support_closing_radius",
+    "remove_freq_sweep", "remove_bed_leveling", "remove_extrusion_calibration",
+    "support_transition_line_width", "support_transition_speed", "bed_temperature",
+    "bed_temperature_initial_layer", "can_switch_nozzle_type", "can_add_auxiliary_fan",
+    "extra_flush_volume", "spaghetti_detector", "adaptive_layer_height",
+    "z_hop_type", "z_lift_type", "bed_temperature_difference", "long_retraction_when_cut",
+    "retraction_distance_when_cut", "extruder_type", "internal_bridge_support_thickness",
+    "extruder_clearance_max_radius", "top_area_threshold", "reduce_wall_solid_infill",
+    "filament_load_time", "filament_unload_time", "smooth_coefficient",
+    "overhang_totally_speed", "silent_mode", "overhang_speed_classic"
+}
+
+# Utility functions for printing messages in different colors.
+def print_error(msg):
+    print(f"\033[91m[ERROR]\033[0m {msg}")  # Red
+
+def print_warning(msg):
+    print(f"\033[93m[WARNING]\033[0m {msg}")  # Yellow
+
+def print_info(msg):
+    print(f"\033[94m[INFO]\033[0m {msg}")  # Blue
+
+def print_success(msg):
+    print(f"\033[92m[SUCCESS]\033[0m {msg}")  # Green
+
+
+# Add helper function for duplicate key detection.
+def no_duplicates_object_pairs_hook(pairs):
+    seen = {}
+    for key, value in pairs:
+        if key in seen:
+            raise ValueError(f"Duplicate key detected: {key}")
+        seen[key] = value
+    return seen
+
+def check_filament_compatible_printers(vendor_folder):
+    """
+    Checks JSON files in the vendor folder for missing or empty 'compatible_printers'
+    when 'instantiation' is flagged as true.
+
+    Parameters:
+        vendor_folder (str or Path): The directory to search for JSON profile files.
+
+    Returns:
+        int: The number of profiles with missing or empty 'compatible_printers'.
+    """
+    error = 0
+    vendor_path = Path(vendor_folder)
+    if not vendor_path.exists():
+        return 0
+    
+    profiles = {}
+
+    # Use rglob to recursively find .json files.
+    for file_path in vendor_path.rglob("*.json"):
+        try:
+            with open(file_path, 'r', encoding='UTF-8') as fp:
+                # Use custom hook to detect duplicates.
+                data = json.load(fp, object_pairs_hook=no_duplicates_object_pairs_hook)
+        except ValueError as ve:
+            print_error(f"Duplicate key error in {file_path}: {ve}")
+            error += 1
+            continue
+        except Exception as e:
+            print_error(f"Error processing {file_path}: {e}")
+            error += 1
+            continue
+
+        profile_name = data['name']
+        if profile_name in profiles:
+            print_error(f"Duplicated profile {profile_name}: {file_path}")
+            error += 1
+            continue
+
+        profiles[profile_name] = {
+            'file_path': file_path,
+            'content': data,
+        }
+    
+    def get_inherit_property(profile, key):
+        content = profile['content']
+        if key in content:
+            return content[key]
+
+        if 'inherits' in content:
+            inherits = content['inherits']
+            if inherits not in profiles:
+                raise ValueError(f"Parent profile not found: {inherits}, referrenced in {profile['file_path']}")
+            
+            return get_inherit_property(profiles[inherits], key)
+        
+        return None
+
+    for profile in profiles.values():
+        instantiation = str(profile['content'].get("instantiation", "")).lower() == "true"
+        if instantiation:
+            try:
+                compatible_printers = get_inherit_property(profile, "compatible_printers")
+                if not compatible_printers or (isinstance(compatible_printers, list) and not compatible_printers):
+                    print_error(f"'compatible_printers' missing in {profile['file_path']}")
+                    error += 1
+            except ValueError as ve:
+                print_error(f"Unable to parse {profile['file_path']}: {ve}")
+                error += 1
+                continue
+
+    return error
+
+def load_available_filament_profiles(profiles_dir, vendor_name):
+    """
+    Load all available filament profiles from a vendor's directory.
+    
+    Parameters:
+        profiles_dir (Path): The directory containing vendor profile directories
+        vendor_name (str): The name of the vendor directory
+        
+    Returns:
+        set: A set of filament profile names
+    """
+    profiles = set()
+    vendor_path = profiles_dir / vendor_name / "filament"
+    
+    if not vendor_path.exists():
+        return profiles
+    
+    for file_path in vendor_path.rglob("*.json"):
+        try:
+            with open(file_path, 'r', encoding='UTF-8') as fp:
+                data = json.load(fp)
+                if "name" in data:
+                    profiles.add(data["name"])
+        except Exception as e:
+            print_error(f"Error loading filament profile {file_path}: {e}")
+    
+    return profiles
+
+def check_machine_default_materials(profiles_dir, vendor_name):
+    """
+    Checks if default materials referenced in machine profiles exist in 
+    the vendor's filament library or in the global OrcaFilamentLibrary.
+    
+    Parameters:
+        profiles_dir (Path): The base profiles directory
+        vendor_name (str): The vendor name to check
+        
+    Returns:
+        int: Number of missing filament references found
+        int: the number of warnings found (0 or 1)
+    """
+    error_count = 0
+    machine_dir = profiles_dir / vendor_name / "machine"
+    
+    if not machine_dir.exists():
+        print_warning(f"No machine profiles found for vendor: {vendor_name}")
+        return 0, 1
+        
+    # Load available filament profiles
+    vendor_filaments = load_available_filament_profiles(profiles_dir, vendor_name)
+    global_filaments = load_available_filament_profiles(profiles_dir, "OrcaFilamentLibrary")
+    all_available_filaments = vendor_filaments.union(global_filaments)
+    
+    # Check each machine profile
+    for file_path in machine_dir.rglob("*.json"):
+        try:
+            with open(file_path, 'r', encoding='UTF-8') as fp:
+                data = json.load(fp)
+                
+            default_materials = None
+            if "default_materials" in data:
+                default_materials = data["default_materials"]
+            elif "default_filament_profile" in data:
+                default_materials = data["default_filament_profile"]
+                
+            if default_materials:
+                if isinstance(default_materials, list):
+                    for material in default_materials:
+                        if material not in all_available_filaments:
+                            print_error(f"Missing filament profile: '{material}' referenced in {file_path.relative_to(profiles_dir)}")
+                            error_count += 1
+                else:
+                    # Handle semicolon-separated list of materials in a string
+                    if ";" in default_materials:
+                        for material in default_materials.split(";"):
+                            material = material.strip()
+                            if material and material not in all_available_filaments:
+                                print_error(f"Missing filament profile: '{material}' referenced in {file_path.relative_to(profiles_dir)}")
+                                error_count += 1
+                    else:
+                        # Single material in a string
+                        if default_materials not in all_available_filaments:
+                            print_error(f"Missing filament profile: '{default_materials}' referenced in {file_path.relative_to(profiles_dir)}")
+                            error_count += 1
+                        
+        except Exception as e:
+            print_error(f"Error processing machine profile {file_path}: {e}")
+            error_count += 1
+            
+    return error_count, 0
+
+def check_filament_name_consistency(profiles_dir, vendor_name):
+    """
+    Make sure filament profile names match in both vendor json and subpath files.
+    Filament profiles work only if the name in <vendor>.json matches the name in sub_path file,
+    or if it's one of the sub_path file's `renamed_from`.
+
+    Parameters:
+        profiles_dir (Path): Base profiles directory
+        vendor_name (str): Vendor name
+
+    Returns:
+        int: Number of errors found
+        int: Number of warnings found (0 or 1)
+    """
+    error_count = 0
+    vendor_dir = profiles_dir / vendor_name
+    vendor_file = profiles_dir / (vendor_name + ".json")
+    
+    if not vendor_file.exists():
+        print_warning(f"No profiles found for vendor: {vendor_name} at {vendor_file}")
+        return 0, 1
+    
+    try:
+        with open(vendor_file, 'r', encoding='UTF-8') as fp:
+            data = json.load(fp)
+    except Exception as e:
+        print_error(f"Error loading vendor profile {vendor_file}: {e}")
+        return 1, 0
+
+    if 'filament_list' not in data:
+        return 0, 0
+    
+    for child in data['filament_list']:
+        name_in_vendor = child['name']
+        sub_path = child['sub_path']
+        sub_file = vendor_dir / sub_path
+
+        if not sub_file.exists():
+            print_error(f"Missing sub profile: '{sub_path}' declared in {vendor_file.relative_to(profiles_dir)}")
+            error_count += 1
+            continue
+
+        try:
+            with open(sub_file, 'r', encoding='UTF-8') as fp:
+                sub_data = json.load(fp)
+        except Exception as e:
+            print_error(f"Error loading profile {sub_file}: {e}")
+            error_count += 1
+            continue
+
+        name_in_sub = sub_data['name']
+
+        if name_in_sub == name_in_vendor:
+            continue
+
+        if 'renamed_from' in sub_data:
+            renamed_from = [n.strip() for n in sub_data['renamed_from'].split(';')]
+            if name_in_vendor in renamed_from:
+                continue
+
+        print_error(f"Filament name mismatch: required '{name_in_vendor}' in {vendor_file.relative_to(profiles_dir)} but found '{name_in_sub}' in {sub_file.relative_to(profiles_dir)}, and none of its `renamed_from` matches the required name either")
+        error_count += 1
+    
+    return error_count, 0
+
+def check_filament_id(vendor, vendor_folder):
+    """
+    Make sure filament_id is not longer than 8 characters, otherwise AMS won't work properly
+    """
+    if vendor not in ('BBL', 'OrcaFilamentLibrary'):
+        return 0
+    
+    error = 0
+    vendor_path = Path(vendor_folder)
+    if not vendor_path.exists():
+        return 0
+
+    # Use rglob to recursively find .json files.
+    for file_path in vendor_path.rglob("*.json"):
+        try:
+            with open(file_path, 'r', encoding='UTF-8') as fp:
+                # Use custom hook to detect duplicates.
+                data = json.load(fp, object_pairs_hook=no_duplicates_object_pairs_hook)
+        except ValueError as ve:
+            print_error(f"Duplicate key error in {file_path}: {ve}")
+            error += 1
+            continue
+        except Exception as e:
+            print_error(f"Error processing {file_path}: {e}")
+            error += 1
+            continue
+
+        if 'filament_id' not in data:
+            continue
+            
+        filament_id = data['filament_id']
+
+        if len(filament_id) > 8:
+            error += 1
+            print_error(f"Filament id too long \"{filament_id}\": {file_path}")
+    
+    return error
+
+def check_obsolete_keys(profiles_dir, vendor_name):
+    """
+    Check for obsolete keys in all filament profiles for a vendor.
+
+    Parameters:
+        profiles_dir (Path): Base profiles directory
+        vendor_name (str): Vendor name
+        obsolete_keys (set): Set of obsolete key names to check
+
+    Returns:
+        int: Number of obsolete keys found
+    """
+    error_count = 0
+    vendor_path = profiles_dir / vendor_name / "filament"
+
+    if not vendor_path.exists():
+        return 0
+
+    for file_path in vendor_path.rglob("*.json"):
+        try:
+            with open(file_path, "r", encoding="UTF-8") as fp:
+                data = json.load(fp)
+        except Exception as e:
+            print_warning(f"Error reading profile {file_path.relative_to(profiles_dir)}: {e}")
+            error_count += 1
+            continue
+
+        for key in data.keys():
+            if key in OBSOLETE_KEYS:
+                print_warning(f"Obsolete key: '{key}' found in {file_path.relative_to(profiles_dir)}")
+                error_count += 1
+
+    return error_count
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check 3D printer profiles for common issues",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--dir", type=str, required=True, help="Root directory containing vendor profiles")
+    parser.add_argument("--vendor", type=str, help="Specify a single vendor to check")
+    parser.add_argument("--check-filaments", action="store_true", help="Check 'compatible_printers' in filament profiles")
+    parser.add_argument("--check-materials", action="store_true", help="Check default materials in machine profiles")
+    parser.add_argument("--check-obsolete-keys", action="store_true", help="Warn if obsolete keys are found in filament profiles")
+    args = parser.parse_args()
+
+    profiles_dir = Path(args.dir).resolve()
+    if not profiles_dir.exists():
+        print_error(f"Provided directory '{profiles_dir}' does not exist.")
+        exit(1)
+
+    print_info(f"Checking profiles in: {profiles_dir}")
+
+    checked_vendor_count = 0
+    errors_found = 0
+    warnings_found = 0
+
+    def run_checks(vendor_name):
+        nonlocal errors_found, warnings_found, checked_vendor_count
+        vendor_path = profiles_dir / vendor_name
+
+        if args.check_filaments or not (args.check_materials and not args.check_filaments):
+            errors_found += check_filament_compatible_printers(vendor_path / "filament")
+
+        if args.check_materials:
+            new_errors, new_warnings = check_machine_default_materials(profiles_dir, vendor_name)
+            errors_found += new_errors
+            warnings_found += new_warnings
+
+        if args.check_obsolete_keys:
+            warnings_found += check_obsolete_keys(profiles_dir, vendor_name)
+
+        new_errors, new_warnings = check_filament_name_consistency(profiles_dir, vendor_name)
+        errors_found += new_errors
+        warnings_found += new_warnings
+
+        errors_found += check_filament_id(vendor_name, vendor_path / "filament")
+        checked_vendor_count += 1
+
+    if args.vendor:
+        run_checks(args.vendor)
+    else:
+        for vendor_dir in profiles_dir.iterdir():
+            if not vendor_dir.is_dir() or vendor_dir.name == "OrcaFilamentLibrary":
+                continue
+            run_checks(vendor_dir.name)
+
+    # ✨ Output finale in stile "compilatore"
+    print("\n==================== SUMMARY ====================")
+    print_info(f"Checked vendors     : {checked_vendor_count}")
+    if errors_found > 0:
+        print_error(f"Files with errors   : {errors_found}")
+    else:
+        print_success("Files with errors   : 0")
+    if warnings_found > 0:
+        print_warning(f"Files with warnings : {warnings_found}")
+    else:
+        print_success("Files with warnings : 0")
+    print("=================================================")
+
+    exit(-1 if errors_found > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/orca_filament_lib.py
+++ b/scripts/orca_filament_lib.py
@@ -1,0 +1,166 @@
+import os
+import json
+import argparse
+from collections import defaultdict
+
+def topological_sort(filaments):
+    # Build a graph of dependencies
+    graph = defaultdict(list)
+    in_degree = defaultdict(int)
+    name_to_filament = {f['name']: f for f in filaments}
+    all_names = set(name_to_filament.keys())
+    
+    # Create the dependency graph
+    processed_files = set()
+    for filament in filaments:
+        if 'inherits' in filament:
+            parent = filament['inherits']
+            child = filament['name']
+            # Only create dependency if parent exists
+            if parent in all_names:
+                graph[parent].append(child)
+                in_degree[child] += 1
+                if parent not in in_degree:
+                    in_degree[parent] = 0
+                processed_files.add(child)
+                processed_files.add(parent)
+
+    # Initialize queue with nodes having no dependencies (now sorted)
+    queue = sorted([name for name, degree in in_degree.items() if degree == 0])
+    result = []
+
+    # Process the queue
+    while queue:
+        current = queue.pop(0)
+        result.append(name_to_filament[current])
+        processed_files.add(current)
+        
+        # Process children (now sorted)
+        children = sorted(graph[current])
+        for child in children:
+            in_degree[child] -= 1
+            if in_degree[child] == 0:
+                queue.append(child)
+
+    # Add remaining files that weren't part of inheritance tree (now sorted)
+    remaining = sorted(all_names - processed_files)
+    for name in remaining:
+        result.append(name_to_filament[name])
+
+    return result
+
+def update_filament_library(vendor="OrcaFilamentLibrary"):
+    # change current working directory to the relative path(..\resources\profiles) compare to script location
+    os.chdir(os.path.join(os.path.dirname(__file__), '..', 'resources', 'profiles'))
+
+    # Collect current filament entries
+    current_filaments = []
+    base_dir = vendor
+    filament_dir = os.path.join(base_dir, 'filament')
+    
+    for root, dirs, files in os.walk(filament_dir):
+        for file in files:
+            if file.lower().endswith('.json'):
+                full_path = os.path.join(root, file)
+                
+                # Get relative path from base directory
+                sub_path = os.path.relpath(full_path, base_dir).replace('\\', '/')
+                
+                try:
+                    with open(full_path, 'r', encoding='utf-8') as f:
+                        filament_data = json.load(f)
+                        name = filament_data.get('name')
+                        inherits = filament_data.get('inherits')
+                        
+                        if name:
+                            entry = {
+                                "name": name,
+                                "sub_path": sub_path
+                            }
+                            if inherits:
+                                entry['inherits'] = inherits
+                            current_filaments.append(entry)
+                        else:
+                            print(f"Warning: Missing 'name' in {full_path}")
+                except Exception as e:
+                    print(f"Error reading {full_path}: {str(e)}")
+                    continue
+
+    # Sort filaments based on inheritance
+    sorted_filaments = topological_sort(current_filaments)
+    
+    # Remove the inherits field as it's not needed in the final JSON
+    for filament in sorted_filaments:
+        filament.pop('inherits', None)
+
+    # Update library file
+    lib_path = f'{vendor}.json'
+    
+    try:
+        with open(lib_path, 'r+', encoding='utf-8') as f:
+            library = json.load(f)
+            library['filament_list'] = sorted_filaments
+            f.seek(0)
+            json.dump(library, f, indent=4, ensure_ascii=False)
+            f.truncate()
+            
+        print(f"Filament library for {vendor} updated successfully!")
+    except Exception as e:
+        print(f"Error updating library file: {str(e)}")
+
+
+# For each JSON file, it will:
+#    - Replace "BBL X1C" with "System" in the name field
+#    - Empty the compatible_printers array
+#    - Ensure setting_id starts with 'O'
+def rename_filament_system(vendor="OrcaFilamentLibrary"):
+    # change current working directory to the relative path
+    os.chdir(os.path.join(os.path.dirname(__file__), '..', 'resources', 'profiles'))
+    
+    base_dir = vendor
+    filament_dir = os.path.join(base_dir, 'filament')
+    
+    for root, dirs, files in os.walk(filament_dir):
+        for file in files:
+            if file.lower().endswith('.json'):
+                full_path = os.path.join(root, file)
+                try:
+                    with open(full_path, 'r', encoding='utf-8') as f:
+                        data = json.load(f)
+                        modified = False
+                        
+                        # Update name if it contains "BBL X1C"
+                        if 'name' in data and "BBL X1C" in data['name']:
+                            data['name'] = data['name'].replace("BBL X1C", "System")
+                            modified = True
+                            
+                        # Empty compatible_printers if exists
+                        if 'compatible_printers' in data:
+                            data['compatible_printers'] = []
+                            modified = True
+                            
+                        # Update setting_id if needed
+                        if 'setting_id' in data and not data['setting_id'].startswith('O'):
+                            data['setting_id'] = 'O' + data['setting_id']
+                            modified = True
+                        
+                        if modified:
+                            with open(full_path, 'w', encoding='utf-8') as f:
+                                json.dump(data, f, indent=4, ensure_ascii=False)
+                            print(f"Updated {full_path}")
+                            
+                except Exception as e:
+                    print(f"Error processing {full_path}: {str(e)}")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Update filament library for specified vendor')
+    parser.add_argument('-v', '--vendor', type=str, default="OrcaFilamentLibrary",
+                      help='Vendor name (default: OrcaFilamentLibrary)')
+    parser.add_argument('-m', '--mode', type=str, choices=['update', 'rename'],
+                      default='update', help='Operation mode (default: update)')
+    args = parser.parse_args()
+    
+    if args.mode == 'update':
+        update_filament_library(args.vendor)
+    else:
+        rename_filament_system(args.vendor)

--- a/scripts/pack_profiles.sh
+++ b/scripts/pack_profiles.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Check if required arguments are provided
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 VERSION NUMBER VENDOR1 [VENDOR2 ...]"
+    echo "Example: $0 2.3.0 1 OrcaFilamentLibrary BBL"
+    exit 1
+fi
+
+# Get version and number from arguments
+VERSION="$1"
+NUMBER="$2"
+shift 2  # Remove first two arguments, leaving only vendor names
+
+# Set paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOURCES_DIR="$SCRIPT_DIR/../profiles/${VERSION}"
+ORIGINAL_DIR="$(pwd)"
+OUTPUT_FILE="orcaslicer-profiles_ota_${VERSION}.${NUMBER}.zip"
+TEMP_DIR="/tmp/orca_profiles_${VERSION}_$$"
+
+# Check if resources directory exists
+if [ ! -d "$RESOURCES_DIR" ]; then
+    echo "Error: Profiles directory not found at $RESOURCES_DIR"
+    exit 1
+fi
+
+# If no vendors specified, collect all vendor directories
+if [ "$#" -eq 0 ]; then
+    VENDORS=()
+    for dir in "$RESOURCES_DIR"/*; do
+        vendor=$(basename "$dir")
+        if [ -d "$RESOURCES_DIR/$vendor" ]; then
+            VENDORS+=("$vendor")
+        fi
+    done
+else
+    VENDORS=("$@")
+fi
+
+# Create temporary directory with profiles root folder
+mkdir -p "$TEMP_DIR/profiles"
+
+# Process each vendor
+for VENDOR in "${VENDORS[@]}"; do
+    echo "Processing vendor: $VENDOR"
+    
+    # Copy JSON file if it exists
+    if [ -f "$RESOURCES_DIR/$VENDOR.json" ]; then
+        cp "$RESOURCES_DIR/$VENDOR.json" "$TEMP_DIR/profiles/"
+        echo "Added $VENDOR.json"
+    else
+        echo "Warning: $VENDOR.json not found"
+    fi
+    
+    # Copy vendor directory if it exists
+    if [ -d "$RESOURCES_DIR/$VENDOR" ]; then
+        cp -r "$RESOURCES_DIR/$VENDOR" "$TEMP_DIR/profiles/"
+        echo "Added $VENDOR directory"
+    else
+        echo "Warning: $VENDOR directory not found"
+    fi
+done
+
+# Create zip file
+cd "$TEMP_DIR"
+zip -r "$OUTPUT_FILE" profiles/
+
+# Move zip file to original directory
+mv "$OUTPUT_FILE" "$ORIGINAL_DIR/"
+
+# Return to original directory
+cd "$ORIGINAL_DIR"
+
+# Clean up
+rm -rf "$TEMP_DIR"
+
+# Print results
+if [ -f "$OUTPUT_FILE" ]; then
+    echo "Created profiles package: $OUTPUT_FILE"
+    echo "Size: $(du -h "$OUTPUT_FILE" | cut -f1)"
+else
+    echo "Error: Failed to create zip file"
+    exit 1
+fi 


### PR DESCRIPTION
# Description
This PR initializes the folder structure for hosting slicer profiles organized by version.
This structure will support OTA updates and help decouple profile management from the main OrcaSlicer repository.

No profiles yet — migration will follow in a separate PR to simplify review and avoid large diffs.

## All Involved PR
[Initialize folder structure and OTA base for profiles repository](https://github.com/OrcaSlicer/orcaslicer-profiles/pull/1)
[Migrate existing JSON profiles from OrcaSlicer repository](https://github.com/OrcaSlicer/orcaslicer-profiles/pull/2)
[Configure OTA profile fetch system using external profile repository](https://github.com/SoftFever/OrcaSlicer/pull/10046)
[Remove legacy embedded profiles in preparation for OTA system](https://github.com/SoftFever/OrcaSlicer/pull/10088)


# Screenshots/Recordings/Graphs
N.A.